### PR TITLE
Add support for negative number in look method

### DIFF
--- a/lib/Twig/TokenStream.php
+++ b/lib/Twig/TokenStream.php
@@ -100,7 +100,7 @@ final class Twig_TokenStream
     public function look($number = 1)
     {
         if (!isset($this->tokens[$this->current + $number])) {
-            throw new Twig_Error_Syntax('Unexpected end of template.', $this->tokens[$this->current + $number - 1]->getLine(), $this->source);
+            throw new Twig_Error_Syntax('Unexpected end of template.', $this->tokens[$this->current + $number + (($number < 0) ? + 1 : - 1)]->getLine(), $this->source);
         }
 
         return $this->tokens[$this->current + $number];


### PR DESCRIPTION
If the number passed to the look function was negative the function throwed a `Exception`.
Now it throws a `Twig_Error_Syntax` as expected.